### PR TITLE
Add social media preview tags

### DIFF
--- a/index.html
+++ b/index.html
@@ -9,6 +9,40 @@
       content="Santosh's Portfolio - Mechanical Engineer and Web Developer showcasing projects in CAD design, robotics, and software engineering."
     />
     <meta name="theme-color" content="#3B82F6" />
+
+    <!-- Open Graph / Facebook Meta Tags -->
+    <meta property="og:type" content="website" />
+    <meta property="og:url" content="https://santoshblds.com/" />
+    <meta
+      property="og:title"
+      content="Santosh's Portfolio | Engineering & Development"
+    />
+    <meta
+      property="og:description"
+      content="Mechanical Engineer and Web Developer showcasing projects in CAD design, robotics, and software engineering."
+    />
+    <meta
+      property="og:image"
+      content="https://santoshblds.com/assets/logo.webp"
+    />
+    <meta property="og:image:alt" content="Santosh Portfolio Logo" />
+
+    <!-- Twitter Meta Tags -->
+    <meta name="twitter:card" content="summary_large_image" />
+    <meta name="twitter:url" content="https://santoshblds.com/" />
+    <meta
+      name="twitter:title"
+      content="Santosh's Portfolio | Engineering & Development"
+    />
+    <meta
+      name="twitter:description"
+      content="Mechanical Engineer and Web Developer showcasing projects in CAD design, robotics, and software engineering."
+    />
+    <meta
+      name="twitter:image"
+      content="https://santoshblds.com/assets/logo.webp"
+    />
+
     <title>Santosh's Portfolio | Engineering & Development</title>
     <link rel="preload" href="./assets/logo.webp" as="image" />
     <link rel="stylesheet" href="./src/index.css" />


### PR DESCRIPTION
This PR adds Open Graph and Twitter Card meta tags to enable social media preview images when links to the site are shared. The logo image is set as the preview image as requested.